### PR TITLE
Sort dependencies before saving package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 const path = require('path');
 const writeJsonFile = require('write-json-file');
+const sortKeys = require('sort-keys');
 
 const opts = {indent: 2};
 
@@ -11,6 +12,8 @@ module.exports = (fp, data) => {
 	}
 
 	fp = path.basename(fp) === 'package.json' ? fp : path.join(fp, 'package.json');
+
+	data = normalize(data);
 
 	return writeJsonFile(fp, data, opts);
 };
@@ -23,5 +26,22 @@ module.exports.sync = (fp, data) => {
 
 	fp = path.basename(fp) === 'package.json' ? fp : path.join(fp, 'package.json');
 
+	data = normalize(data);
+
 	writeJsonFile.sync(fp, data, opts);
 };
+
+const dependencyKeys = new Set([
+	'dependencies',
+	'devDependencies',
+	'optionalDependencies',
+	'peerDependencies'
+]);
+
+function normalize(pkg) {
+	const npkg = {};
+	for (const key of Object.keys(pkg)) {
+		npkg[key] = dependencyKeys.has(key) ? sortKeys(pkg[key]) : pkg[key];
+	}
+	return npkg;
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "package"
   ],
   "dependencies": {
+    "sort-keys": "^1.1.2",
     "write-json-file": "^2.0.0"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > Write a `package.json` file
 
-Writes atomically and creates directories for you as needed.
+Writes atomically and creates directories for you as needed. Sorts dependencies when writing.
 
 
 ## Install

--- a/test.js
+++ b/test.js
@@ -4,18 +4,44 @@ const tempfile = require('tempfile');
 const readPkg = require('read-pkg');
 const m = require('./');
 
-const fixture = {foo: true};
+const fixture = {
+	foo: true,
+	dependencies: {
+		foo: '1.0.0',
+		bar: '1.0.0'
+	},
+	devDependencies: {
+		foo: '1.0.0',
+		bar: '1.0.0'
+	},
+	optionalDependencies: {
+		foo: '1.0.0',
+		bar: '1.0.0'
+	},
+	peerDependencies: {
+		foo: '1.0.0',
+		bar: '1.0.0'
+	}
+};
 
 test('async', async t => {
 	const tmp = tempfile();
 	await m(tmp, fixture);
-	const x = await readPkg(tmp);
+	const x = await readPkg(tmp, {normalize: false});
 	t.true(x.foo);
+	t.deepEqual(Object.keys(x.dependencies), ['bar', 'foo']);
+	t.deepEqual(Object.keys(x.devDependencies), ['bar', 'foo']);
+	t.deepEqual(Object.keys(x.optionalDependencies), ['bar', 'foo']);
+	t.deepEqual(Object.keys(x.peerDependencies), ['bar', 'foo']);
 });
 
 test('sync', t => {
 	const tmp = tempfile();
 	m.sync(tmp, fixture);
-	const x = readPkg.sync(tmp);
+	const x = readPkg.sync(tmp, {normalize: false});
 	t.true(x.foo);
+	t.deepEqual(Object.keys(x.dependencies), ['bar', 'foo']);
+	t.deepEqual(Object.keys(x.devDependencies), ['bar', 'foo']);
+	t.deepEqual(Object.keys(x.optionalDependencies), ['bar', 'foo']);
+	t.deepEqual(Object.keys(x.peerDependencies), ['bar', 'foo']);
 });


### PR DESCRIPTION
Sorts the `dependencies`, `devDependencies` and
`optionalDependencies` properties.

Fixes #2