### PR TITLE
Remove some empty properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,12 @@ function normalize(pkg) {
 	const ret = {};
 
 	for (const key of Object.keys(pkg)) {
-		ret[key] = dependencyKeys.has(key) ? sortKeys(pkg[key]) : pkg[key];
+		if (!dependencyKeys.has(key)) {
+			ret[key] = pkg[key];
+		}
+		if (Object.keys(pkg[key]).length !== 0) {
+			ret[key] = sortKeys(pkg[key]);
+		}
 	}
 
 	return ret;

--- a/test.js
+++ b/test.js
@@ -45,3 +45,33 @@ test('sync', t => {
 	t.deepEqual(Object.keys(x.optionalDependencies), ['bar', 'foo']);
 	t.deepEqual(Object.keys(x.peerDependencies), ['bar', 'foo']);
 });
+
+const emptyPropFixture = {
+	foo: true,
+	dependencies: {},
+	devDependencies: {},
+	optionalDependencies: {},
+	peerDependencies: {}
+};
+
+test('removes empty dependency properties', async t => {
+	const tmp = tempfile();
+	await m(tmp, emptyPropFixture);
+	const x = await readPkg(tmp, {normalize: false});
+	t.true(x.foo);
+	t.falsy(x.dependencies);
+	t.falsy(x.devDependencies);
+	t.falsy(x.optionalDependencies);
+	t.falsy(x.peerDependencies);
+});
+
+test('removes empty dependency properties sync', t => {
+	const tmp = tempfile();
+	m.sync(tmp, emptyPropFixture);
+	const x = readPkg.sync(tmp, {normalize: false});
+	t.true(x.foo);
+	t.falsy(x.dependencies);
+	t.falsy(x.devDependencies);
+	t.falsy(x.optionalDependencies);
+	t.falsy(x.peerDependencies);
+});


### PR DESCRIPTION
The `dependencies`, `devDependencies`, `optionalDependencies` and
`peerDependencies` properties are removed before saving if they
are empty.

Closes #4