### PR TITLE
Should sort only dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,9 +18,7 @@ function normalize(pkg) {
 	for (const key of Object.keys(pkg)) {
 		if (!dependencyKeys.has(key)) {
 			ret[key] = pkg[key];
-		}
-
-		if (Object.keys(pkg[key]).length !== 0) {
+		} else if (Object.keys(pkg[key]).length !== 0) {
 			ret[key] = sortKeys(pkg[key]);
 		}
 	}

--- a/test.js
+++ b/test.js
@@ -6,6 +6,10 @@ const m = require('.');
 
 const fixture = {
 	foo: true,
+	scripts: {
+		b: '1',
+		a: '1'
+	},
 	dependencies: {
 		foo: '1.0.0',
 		bar: '1.0.0'
@@ -29,6 +33,7 @@ test('async', async t => {
 	await m(tmp, fixture);
 	const x = await readPkg(tmp, {normalize: false});
 	t.true(x.foo);
+	t.deepEqual(Object.keys(x.scripts), ['b', 'a']);
 	t.deepEqual(Object.keys(x.dependencies), ['bar', 'foo']);
 	t.deepEqual(Object.keys(x.devDependencies), ['bar', 'foo']);
 	t.deepEqual(Object.keys(x.optionalDependencies), ['bar', 'foo']);
@@ -40,6 +45,7 @@ test('sync', t => {
 	m.sync(tmp, fixture);
 	const x = readPkg.sync(tmp, {normalize: false});
 	t.true(x.foo);
+	t.deepEqual(Object.keys(x.scripts), ['b', 'a']);
 	t.deepEqual(Object.keys(x.dependencies), ['bar', 'foo']);
 	t.deepEqual(Object.keys(x.devDependencies), ['bar', 'foo']);
 	t.deepEqual(Object.keys(x.optionalDependencies), ['bar', 'foo']);


### PR DESCRIPTION
Sorry, I did a fatal mistake in the previous PR. It fails on the first `string` property, because it is passed to sort-keys. Also it sorts not only properties with dependencies.