### PR TITLE
Improve options type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 import {JsonObject} from 'type-fest';
+import {Options as WriteJsonFileOptions} from 'write-json-file';
 
-export interface Options {
+export interface Options extends Omit<WriteJsonFileOptions, 'detectIndent'> {
 	/**
 	Remove empty `dependencies`, `devDependencies`, `optionalDependencies` and `peerDependencies` objects.
 


### PR DESCRIPTION
In javascript code options are spread to options argument for write-json-file but in types for write-pkg there is only normalize option.