### PR TITLE
Target Node.js 18, fix adding dependencies when no path given

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,6 @@ jobs:
         node-version:
           - 20
           - 18
-          - 16
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,8 @@ jobs:
           - 20
           - 18
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 21
           - 20
           - 18
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ jobs:
           - 21
           - 20
           - 18
+          - 16
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,7 @@ export type Options = {
 /**
 A JSON object with suggested fields for [npm's `package.json` file](https://docs.npmjs.com/creating-a-package-json-file).
 */
-type PackageJsonData = PackageJson | JsonObject; // eslint-disable-line @typescript-eslint/no-redundant-type-constituents
+type PackageJsonData = PackageJson | JsonObject;
 
 /**
 Write a `package.json` file.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"type": "module",
 	"exports": "./index.js",
 	"engines": {
-		"node": ">=18"
+		"node": ">=16"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"

--- a/package.json
+++ b/package.json
@@ -41,9 +41,16 @@
 	},
 	"devDependencies": {
 		"ava": "^5.3.1",
+		"esmock": "^2.5.8",
 		"filter-anything": "^3.0.7",
 		"tempy": "^3.1.0",
 		"tsd": "^0.29.0",
 		"xo": "^0.56.0"
+	},
+	"ava": {
+		"nodeArguments": [
+			"--loader=esmock",
+			"--no-warnings=ExperimentalWarning"
+		]
 	}
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"type": "module",
 	"exports": "./index.js",
 	"engines": {
-		"node": ">=16"
+		"node": ">=18"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"
@@ -34,16 +34,16 @@
 	],
 	"dependencies": {
 		"deepmerge-ts": "^5.1.0",
-		"read-pkg": "^8.0.0",
+		"read-pkg": "^8.1.0",
 		"sort-keys": "^5.0.0",
-		"type-fest": "^3.13.0",
+		"type-fest": "^4.6.0",
 		"write-json-file": "^5.0.0"
 	},
 	"devDependencies": {
 		"ava": "^5.3.1",
 		"filter-anything": "^3.0.7",
 		"tempy": "^3.1.0",
-		"tsd": "^0.28.1",
-		"xo": "^0.54.2"
+		"tsd": "^0.29.0",
+		"xo": "^0.56.0"
 	}
 }

--- a/source/add-remove-dependencies.js
+++ b/source/add-remove-dependencies.js
@@ -5,13 +5,13 @@ import {updatePackage, updatePackageSync} from './update-package.js';
 import {sanitize, normalize, hasMultipleDependencyTypes} from './util.js';
 
 export async function addPackageDependencies(filePath, dependencies, options) {
-	return hasMultipleDependencyTypes(dependencies)
+	return hasMultipleDependencyTypes(typeof filePath === 'string' ? dependencies : filePath)
 		? updatePackage(filePath, {...dependencies}, options)
 		: updatePackage(filePath, {dependencies}, options);
 }
 
 export function addPackageDependenciesSync(filePath, dependencies, options) {
-	return hasMultipleDependencyTypes(dependencies)
+	return hasMultipleDependencyTypes(typeof filePath === 'string' ? dependencies : filePath)
 		? updatePackageSync(filePath, {...dependencies}, options)
 		: updatePackageSync(filePath, {dependencies}, options);
 }

--- a/test/no-path.js
+++ b/test/no-path.js
@@ -1,0 +1,123 @@
+import test from 'ava';
+import esmock from 'esmock';
+import {temporaryDirectory} from 'tempy';
+import {readPackage, readPackageSync} from 'read-pkg';
+import {writePackage} from '../index.js';
+
+/** @type {import('./types').NoPathMacro} */
+const verifyPackage = test.macro(async (t, {fixture, assertions}) => {
+	const temporaryDir = temporaryDirectory();
+
+	if (fixture) {
+		await writePackage(temporaryDir, fixture);
+	}
+
+	const testedModule = await esmock('../index.js', {}, {
+		'node:path': {join: () => `${temporaryDir}/package.json`},
+	});
+
+	const getPackageJson = async () => readPackage({cwd: temporaryDir, normalize: false});
+	await assertions({t, testedModule, getPackageJson});
+});
+
+const writeFixture = {
+	foo: true,
+	scripts: {
+		b: '1',
+		a: '1',
+	},
+	dependencies: {
+		foo: '1.0.0',
+		bar: '1.0.0',
+	},
+	devDependencies: {
+		foo: '1.0.0',
+		bar: '1.0.0',
+	},
+	optionalDependencies: {
+		foo: '1.0.0',
+		bar: '1.0.0',
+	},
+	peerDependencies: {
+		foo: '1.0.0',
+		bar: '1.0.0',
+	},
+};
+
+const addFixture = {
+	dependencies: {
+		baz: '1.0.0',
+	},
+	devDependencies: {
+		baz: '1.0.0',
+	},
+	optionalDependencies: {
+		baz: '1.0.0',
+	},
+	peerDependencies: {
+		baz: '1.0.0',
+	},
+};
+
+test('async - writePackage', verifyPackage, {
+	async assertions({t, testedModule: {writePackage}, getPackageJson}) {
+		await writePackage(writeFixture);
+		const packageJson = await getPackageJson();
+
+		t.true(packageJson.foo);
+		t.deepEqual(Object.keys(packageJson.scripts), ['b', 'a']);
+		t.deepEqual(Object.keys(packageJson.dependencies), ['bar', 'foo']);
+		t.deepEqual(Object.keys(packageJson.devDependencies), ['bar', 'foo']);
+		t.deepEqual(Object.keys(packageJson.optionalDependencies), ['bar', 'foo']);
+		t.deepEqual(Object.keys(packageJson.peerDependencies), ['bar', 'foo']);
+	},
+});
+
+test('async - updatePackage', verifyPackage, {
+	fixture: {name: 'foo', version: '1.0.0'},
+	async assertions({t, testedModule: {updatePackage}, getPackageJson}) {
+		await updatePackage({version: '2.0.0', license: 'MIT'});
+		const packageJson = await getPackageJson();
+
+		t.deepEqual(packageJson, {
+			name: 'foo',
+			version: '2.0.0',
+			license: 'MIT',
+		});
+	},
+});
+
+test('async - addPackageDependencies', verifyPackage, {
+	fixture: writeFixture,
+	async assertions({t, testedModule: {addPackageDependencies}, getPackageJson}) {
+		await addPackageDependencies(addFixture);
+		const packageJson = await getPackageJson();
+
+		t.true(packageJson.foo);
+		t.deepEqual(Object.keys(packageJson.scripts), ['b', 'a']);
+		t.deepEqual(Object.keys(packageJson.dependencies), ['bar', 'baz', 'foo']);
+		t.deepEqual(Object.keys(packageJson.devDependencies), ['bar', 'baz', 'foo']);
+		t.deepEqual(Object.keys(packageJson.optionalDependencies), ['bar', 'baz', 'foo']);
+		t.deepEqual(Object.keys(packageJson.peerDependencies), ['bar', 'baz', 'foo']);
+	},
+});
+
+test('async - removePackageDependencies', verifyPackage, {
+	fixture: writeFixture,
+	async assertions({t, testedModule: {removePackageDependencies}, getPackageJson}) {
+		await removePackageDependencies({
+			dependencies: ['foo'],
+			devDependencies: ['bar'],
+			optionalDependencies: ['foo'],
+			peerDependencies: ['bar'],
+		});
+		const packageJson = await getPackageJson();
+
+		t.true(packageJson.foo);
+		t.deepEqual(Object.keys(packageJson.scripts), ['b', 'a']);
+		t.deepEqual(Object.keys(packageJson.dependencies), ['bar']);
+		t.deepEqual(Object.keys(packageJson.devDependencies), ['foo']);
+		t.deepEqual(Object.keys(packageJson.optionalDependencies), ['bar']);
+		t.deepEqual(Object.keys(packageJson.peerDependencies), ['foo']);
+	},
+});

--- a/test/no-path.js
+++ b/test/no-path.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import esmock from 'esmock';
 import {temporaryDirectory} from 'tempy';
-import {readPackage, readPackageSync} from 'read-pkg';
+import {readPackage} from 'read-pkg';
 import {writePackage} from '../index.js';
 
 /** @type {import('./types').NoPathMacro} */
@@ -106,6 +106,69 @@ test('async - removePackageDependencies', verifyPackage, {
 	fixture: writeFixture,
 	async assertions({t, testedModule: {removePackageDependencies}, getPackageJson}) {
 		await removePackageDependencies({
+			dependencies: ['foo'],
+			devDependencies: ['bar'],
+			optionalDependencies: ['foo'],
+			peerDependencies: ['bar'],
+		});
+		const packageJson = await getPackageJson();
+
+		t.true(packageJson.foo);
+		t.deepEqual(Object.keys(packageJson.scripts), ['b', 'a']);
+		t.deepEqual(Object.keys(packageJson.dependencies), ['bar']);
+		t.deepEqual(Object.keys(packageJson.devDependencies), ['foo']);
+		t.deepEqual(Object.keys(packageJson.optionalDependencies), ['bar']);
+		t.deepEqual(Object.keys(packageJson.peerDependencies), ['foo']);
+	},
+});
+
+test('sync - writePackage', verifyPackage, {
+	async assertions({t, testedModule: {writePackageSync}, getPackageJson}) {
+		writePackageSync(writeFixture);
+		const packageJson = await getPackageJson();
+
+		t.true(packageJson.foo);
+		t.deepEqual(Object.keys(packageJson.scripts), ['b', 'a']);
+		t.deepEqual(Object.keys(packageJson.dependencies), ['bar', 'foo']);
+		t.deepEqual(Object.keys(packageJson.devDependencies), ['bar', 'foo']);
+		t.deepEqual(Object.keys(packageJson.optionalDependencies), ['bar', 'foo']);
+		t.deepEqual(Object.keys(packageJson.peerDependencies), ['bar', 'foo']);
+	},
+});
+
+test('sync - updatePackage', verifyPackage, {
+	fixture: {name: 'foo', version: '1.0.0'},
+	async assertions({t, testedModule: {updatePackageSync}, getPackageJson}) {
+		updatePackageSync({version: '2.0.0', license: 'MIT'});
+		const packageJson = await getPackageJson();
+
+		t.deepEqual(packageJson, {
+			name: 'foo',
+			version: '2.0.0',
+			license: 'MIT',
+		});
+	},
+});
+
+test('sync - addPackageDependencies', verifyPackage, {
+	fixture: writeFixture,
+	async assertions({t, testedModule: {addPackageDependenciesSync}, getPackageJson}) {
+		addPackageDependenciesSync(addFixture);
+		const packageJson = await getPackageJson();
+
+		t.true(packageJson.foo);
+		t.deepEqual(Object.keys(packageJson.scripts), ['b', 'a']);
+		t.deepEqual(Object.keys(packageJson.dependencies), ['bar', 'baz', 'foo']);
+		t.deepEqual(Object.keys(packageJson.devDependencies), ['bar', 'baz', 'foo']);
+		t.deepEqual(Object.keys(packageJson.optionalDependencies), ['bar', 'baz', 'foo']);
+		t.deepEqual(Object.keys(packageJson.peerDependencies), ['bar', 'baz', 'foo']);
+	},
+});
+
+test('sync - removePackageDependencies', verifyPackage, {
+	fixture: writeFixture,
+	async assertions({t, testedModule: {removePackageDependenciesSync}, getPackageJson}) {
+		removePackageDependenciesSync({
 			dependencies: ['foo'],
 			devDependencies: ['bar'],
 			optionalDependencies: ['foo'],

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,0 +1,12 @@
+import type {Macro, ExecutionContext} from 'ava';
+import type {PackageJson} from 'type-fest';
+import type * as writePkg from '../index.js';
+
+export type NoPathMacro = Macro<[{
+	fixture?: PackageJson;
+	assertions: (_: {
+		t: ExecutionContext;
+		testedModule: typeof writePkg;
+		getPackageJson: () => Promise<PackageJson>;
+	}) => Promise<void>;
+}]>;


### PR DESCRIPTION
Fixes #22

* Targets Node.js 18
	* Removes Node.js 16 from the test matrix (should Node.js 21 be added?)
* Updates dependencies
* Adds tests for omitting the optional `filePath` parameter
* Fixes `addPackageDependency` when not providing a `filePath`

I wasn't able to reproduce #23.